### PR TITLE
[7571] add ai feedback to comment

### DIFF
--- a/apps/ai_reports/models.py
+++ b/apps/ai_reports/models.py
@@ -14,3 +14,6 @@ class AiReport(TimeStampedModel):
         on_delete=models.CASCADE,
         related_name="ai_report",
     )
+
+    def __str__(self):
+        return "%s" % (self.explanation)

--- a/apps/ai_reports/serializers.py
+++ b/apps/ai_reports/serializers.py
@@ -1,0 +1,13 @@
+from rest_framework import serializers
+
+from apps.ai_reports.models import AiReport
+
+
+class AiReportSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = AiReport
+        fields = (
+            "explanation",
+            "category",
+            "comment",
+        )

--- a/apps/moderatorfeedback/serializers.py
+++ b/apps/moderatorfeedback/serializers.py
@@ -34,12 +34,11 @@ class ModeratorCommentFeedbackSerializer(serializers.ModelSerializer):
 
 class CommentWithFeedbackSerializer(a4_serializers.CommentSerializer):
     moderator_feedback = ModeratorCommentFeedbackSerializer(read_only=True)
+    ai_report = serializers.StringRelatedField(read_only=True)
 
     class Meta:
         model = Comment
-        read_only_fields = a4_serializers.CommentSerializer.Meta.read_only_fields + (
-            "moderator_comment_feedback",
-        )
+        read_only_fields = a4_serializers.CommentSerializer.Meta.read_only_fields
         exclude = ("creator",)
 
 

--- a/changelog/7571.md
+++ b/changelog/7571.md
@@ -1,0 +1,3 @@
+### Added
+
+- Ai report serializer for comments viewset (#7571)

--- a/tests/moderatorfeedback/conftest.py
+++ b/tests/moderatorfeedback/conftest.py
@@ -1,8 +1,10 @@
 from pytest_factoryboy import register
 
+from tests.ai_reports.factories import AiReportFactory
 from tests.ideas.factories import IdeaFactory
 
 from .factories import ModeratorCommentFeedbackFactory
 
+register(AiReportFactory)
 register(IdeaFactory)
 register(ModeratorCommentFeedbackFactory)

--- a/tests/moderatorfeedback/test_moderator_comment_feedback_api.py
+++ b/tests/moderatorfeedback/test_moderator_comment_feedback_api.py
@@ -5,6 +5,39 @@ from apps.moderatorfeedback.models import ModeratorCommentFeedback
 
 
 @pytest.mark.django_db
+def test_moderator_and_ai_report_added_in_comment(
+    idea,
+    comment_factory,
+    apiclient,
+    moderator_comment_feedback_factory,
+    ai_report_factory,
+):
+    comment = comment_factory(content_object=idea)
+    feedback = moderator_comment_feedback_factory(
+        comment=comment,
+    )
+    assert feedback.project == comment.project
+
+    ai_report = ai_report_factory(comment=comment)
+    url = reverse(
+        "comments-detail",
+        kwargs={
+            "pk": comment.pk,
+            "content_type": comment.content_type.pk,
+            "object_pk": comment.object_pk,
+        },
+    )
+    response = apiclient.get(url)
+    assert (
+        feedback.feedback_text in response.data["moderator_feedback"]["feedback_text"]
+    )
+    assert comment.ai_report.explanation == ai_report.explanation
+
+    assert ai_report.explanation in response.data["ai_report"]
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
 def test_anonymous_cannot_add_feedback(apiclient, idea, comment_factory):
     comment = comment_factory(pk=1, content_object=idea)
 


### PR DESCRIPTION
to be merged after this one #6 
relevant files in this PR:
```
	modified:   adhocracy-plus/config/urls.py
	modified:   apps/moderatorfeedback/api.py
	modified:   apps/moderatorfeedback/serializers.py
	modified:   tests/moderatorfeedback/conftest.py
	modified:   tests/moderatorfeedback/test_moderator_comment_feedback_api.py
	added:      apps/ai_reports/serializers.py
```
respective api urls:
```
http://localhost:8004/api/comments/<comment_pk>/aicomments/
http://localhost:8004/api/contenttypes/<contant_type_pk>/objects/<comment_pk>/comments/<comment_pk>/
```
need to create an ai_report for testing purposes, see the test i added.
@hklarner need help with debugging why ai feedback still not part of the comment serializer, while I can access the ai_feedback api response alone. see screenshots:
![image](https://github.com/liqd/a4-defakts/assets/5695572/5130aa73-ce7a-40de-8dfb-361343347eff)
![image](https://github.com/liqd/a4-defakts/assets/5695572/4dc0cca1-50d0-4419-92c5-6e39d61cd456)

