### PR TITLE
version bump: adhocracy4 @ 36679

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.4",
     "@maplibre/maplibre-gl-leaflet": "0.0.19",
-    "adhocracy4": "git+https://github.com/liqd/adhocracy4#8a5484d0b77db4bb168e5831c9026a9bddae3e14",
+    "adhocracy4": "git+https://github.com/liqd/adhocracy4#3667914780c656b20a25b607b06fac05072a6e5d",
     "autoprefixer": "10.4.14",
     "bootstrap": "5.2.3",
     "css-loader": "6.8.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@8a5484d0b77db4bb168e5831c9026a9bddae3e14#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@3667914780c656b20a25b607b06fac05072a6e5d#egg=adhocracy4
 
 # Additional requirements
 brotli==1.0.9


### PR DESCRIPTION
- brings in the new report serializer so that the user reports in the moderation comment list have the additional fields `username` and `created`