### PR TITLE
[#8580] aiReport: update to new API and change display

### DIFF
--- a/adhocracy-plus/assets/scss/_variables.scss
+++ b/adhocracy-plus/assets/scss/_variables.scss
@@ -9,7 +9,8 @@ $brand-tertiary: $brand-primary !default;
 $brand-success: #23865e !default;
 $brand-info: $brand-primary !default; // $brand-primary from platform.scss
 $brand-warning: #ffc107 !default;
-$brand-danger: #9b1d20 !default;
+$brand-danger: #DE4B31 !default;
+$brand-danger-light: #FFEFED !default;
 
 $primary:       $brand-primary !default;
 $secondary:     $brand-secondary !default;

--- a/adhocracy-plus/assets/scss/components/_a4-confidence-circle.scss
+++ b/adhocracy-plus/assets/scss/components/_a4-confidence-circle.scss
@@ -1,0 +1,4 @@
+.a4-confidence-circle {
+    flex-shrink: 0;
+    margin-right: 1em;
+}

--- a/adhocracy-plus/assets/scss/components/_alerts.scss
+++ b/adhocracy-plus/assets/scss/components/_alerts.scss
@@ -18,6 +18,10 @@ $messages-margin-bottom: 25px;
     text-align: center;
     border-radius: 0;
     flex: 1 1 auto;
+
+    .btn--link {
+        font-weight: 700;
+    }
 }
 
 .alert--success {
@@ -27,7 +31,7 @@ $messages-margin-bottom: 25px;
 
 .alert--error,
 .alert--danger {
-    background-color: lighten($brand-danger, 55);
+    background-color: $brand-danger-light;
     color: $text-color;
 }
 

--- a/adhocracy-plus/assets/scss/style.scss
+++ b/adhocracy-plus/assets/scss/style.scss
@@ -64,6 +64,7 @@
 @import "components/a4-poll";
 @import "components/a4-termsofuse";
 @import "components/a4-textarea_with_counter";
+@import "components/a4-confidence-circle";
 @import "components/action";
 @import "components/accordion";
 @import "components/account";

--- a/apps/ai_reports/tasks.py
+++ b/apps/ai_reports/tasks.py
@@ -1,5 +1,3 @@
-import ast
-
 import backoff
 import httpx
 from celery import shared_task
@@ -46,11 +44,9 @@ def call_ai_api(comment: str) -> httpx.Response:
 
 
 def extract_and_save_ai_classifications(comment: Comment, report: dict) -> None:
-    # FIXME: the data returned from the api is not actually valid json, so we need
-    # to use ast to explicitly convert it. This should be fixed on their side.
-    confidence = ast.literal_eval((report["confidence"]))
-    label = ast.literal_eval(report["label"])
-    explanation = ast.literal_eval(report["explanation"])
+    confidence = report["confidence"]
+    label = report["label"]
+    explanation = report["explanation"]
 
     ai_report = AiReport(
         comment=comment, confidence=confidence, label=label, explanation=explanation

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fortawesome/fontawesome-free": "5.15.4",
     "@maplibre/maplibre-gl-leaflet": "0.0.22",
     "@react-leaflet/core": "^2.1.0",
-    "adhocracy4": "git+https://github.com/liqd/adhocracy4#aplus-v2501.1.2",
+    "adhocracy4": "git+https://github.com/liqd/adhocracy4#313861e8f9e6c5b2d65221d1d2bd09ce7569580f",
     "autoprefixer": "10.4.20",
     "bootstrap": "5.2.3",
     "css-loader": "7.1.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@aplus-v2501.1.2#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@313861e8f9e6c5b2d65221d1d2bd09ce7569580f#egg=adhocracy4
 
 # Additional requirements
 brotli==1.1.0


### PR DESCRIPTION
This is the PR for 8580/ the API changes **and** the userfront ticket. Since both was so bound together for me I just did it both in one go.

I talked with @CarolingerSeilchenspringer about the old API and old AI Report models in the database, and we agreed it's fine to delete everything comment/ai report related that is on dev-server so that we don't run into issues where we have the old data in the DB and the new data in the DB.

Regarding "check how django model corresponds to the JSON AI response" I did not do any work there, as it was technically still working with the fields all just being JSONFields. 

There's the task "add docs for API call from the terminal" maybe you can check that and do that once you get to it, because I am unsure what all you want to write in there.

Other than that, all the required changes for the acceptance criterias to be met are already included.

Final note, as [discussed here](https://mattermost.liqd.net/liqd/pl/a589qfibaidxf83ziqt98fbwec), we decided to branch off off a4 because of issues mentioned in the thread that would cost additional time. The [branch](https://github.com/liqd/adhocracy4/tree/defakts-v2501.1.2-branch-off) is `defakts-v2501.1.2-branch-off`.

I will be gone until the 28th now, so you'll have to talk to @CarolingerSeilchenspringer if I should do any changes you request or you want to do them yourselves.